### PR TITLE
Add formatting CI check with parallel Style job

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,25 @@
+name: cd
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.0'
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Build production app
+        run: ./scripts/buildprod.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
           echo "All tests passed!"
           exit 0
 
+      - name: Install gosec
+        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+
+      - name: Run gosec security scan
+        run: gosec ./...
+
   style:
     name: Style
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,9 @@ jobs:
 
       - name: Check formatting
         run: test -z $(go fmt ./...)
+
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+
+      - name: Run staticcheck
+        run: staticcheck ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,19 @@ jobs:
         run: |
           echo "All tests passed!"
           exit 0
+
+  style:
+    name: Style
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.0'
+
+      - name: Check formatting
+        run: test -z $(go fmt ./...)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: ci
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 jobs:
   tests:
@@ -26,10 +24,8 @@ jobs:
       - name: Build
         run: go build -v -o notely
 
-      - name: Simple test check
-        run: |
-          echo "All tests passed!"
-          exit 0
+      - name: Run tests
+        run: go test ./...
 
       - name: Install gosec
         run: go install github.com/securego/gosec/v2/cmd/gosec@latest

--- a/json.go
+++ b/json.go
@@ -27,5 +27,7 @@ func respondWithJSON(w http.ResponseWriter, code int, payload interface{}) {
 		return
 	}
 	w.WriteHeader(code)
-	w.Write(dat)
+	if _, err := w.Write(dat); err != nil {
+		log.Printf("Error writing response: %s", err)
+	}
 }

--- a/json.go
+++ b/json.go
@@ -16,11 +16,8 @@ func respondWithError(w http.ResponseWriter, code int, msg string, logErr error)
 	type errorResponse struct {
 		Error string `json:"error"`
 	}
-	respondWithJSON(w, code, errorResponse{
-		Error: msg,
-	})
+	respondWithJSON(w, code, errorResponse{Error: msg})
 }
-
 func respondWithJSON(w http.ResponseWriter, code int, payload interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	dat, err := json.Marshal(payload)

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/cors"
@@ -89,8 +90,12 @@ func main() {
 
 	router.Mount("/v1", v1Router)
 	srv := &http.Server{
-		Addr:    ":" + port,
-		Handler: router,
+		Addr:              ":" + port,
+		Handler:           router,
+		ReadHeaderTimeout: 30 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	log.Printf("Serving on port: %s\n", port)

--- a/main.go
+++ b/main.go
@@ -96,8 +96,3 @@ func main() {
 	log.Printf("Serving on port: %s\n", port)
 	log.Fatal(srv.ListenAndServe())
 }
-
-// unusedFunction is intentionally unused to test staticcheck
-func unusedFunction() string {
-	return "This function is not used anywhere"
-}

--- a/main.go
+++ b/main.go
@@ -96,3 +96,8 @@ func main() {
 	log.Printf("Serving on port: %s\n", port)
 	log.Fatal(srv.ListenAndServe())
 }
+
+// unusedFunction is intentionally unused to test staticcheck
+func unusedFunction() string {
+	return "This function is not used anywhere"
+}


### PR DESCRIPTION
This PR adds a new 'Style' job to the CI workflow that runs in parallel with the existing 'Tests' job. The Style job checks for Go formatting issues using 'test -z $(go fmt ./...)' command. This ensures code formatting standards are maintained automatically in CI.